### PR TITLE
Bug/13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,11 +88,26 @@ checksum = "d17bf219fcd37199b9a29e00ba65dfb8cd5b2688b7297ec14ff829c40ac50ca9"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "indexmap",
+ "lazy_static",
  "os_str_bytes",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b9752c030a14235a0bd5ef3ad60a1dcac8468c30921327fc8af36b20c790b9"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -265,6 +280,15 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -621,6 +645,30 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1130,6 +1178,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,6 +32,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 name = "aws-login"
 version = "1.0.1"
 dependencies = [
+ "clap",
  "crossterm",
  "home",
  "lazy_static",
@@ -48,7 +40,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "structopt",
  "tokio",
  "which",
 ]
@@ -91,17 +82,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "d17bf219fcd37199b9a29e00ba65dfb8cd5b2688b7297ec14ff829c40ac50ca9"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "indexmap",
+ "os_str_bytes",
  "strsim",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
+ "termcolor",
+ "textwrap",
 ]
 
 [[package]]
@@ -274,15 +265,6 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -577,6 +559,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,30 +621,6 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -767,7 +734,7 @@ checksum = "f7f8e70d25cbc5d14d73c4f0c313ef505450a7c2a39b7e2ca421bc456a4574f6"
 dependencies = [
  "bitflags",
  "crossterm",
- "textwrap 0.14.2",
+ "textwrap",
  "unicode-segmentation",
 ]
 
@@ -954,33 +921,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1008,12 +951,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "termcolor"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
- "unicode-width",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1189,18 +1132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1249,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["aws", "login"]
 categories = ["command-line-utilities"]
 
 [dependencies]
+clap = "^3.0"
 crossterm = "^0.22"
 home = "^0.5"
 lazy_static = "^1.4"
@@ -20,7 +21,6 @@ requestty = { version = "^0.2", features = ["crossterm"] }
 reqwest = { version = "0.11", features = ["blocking"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
-structopt = "^0.3"
 tokio = { version = "^1.15", features = ["full"] }
 which = "^4.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["aws", "login"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-clap = "^3.0"
+clap = { version = "^3.0", features = ["derive"] }
 crossterm = "^0.22"
 home = "^0.5"
 lazy_static = "^1.4"

--- a/src/app/application.rs
+++ b/src/app/application.rs
@@ -2,22 +2,21 @@
 
 use crate::app::{subcommand, Execute};
 use std::{io, sync};
-use structopt::clap;
 
 /// Manages the global command line options.
-#[derive(structopt::StructOpt)]
-#[structopt(global_setting(clap::AppSettings::ColoredHelp))]
+#[derive(clap::Parser)]
+#[clap(about, version, author)]
 pub struct Application {
     /// Overrides the active AWS CLI profile.
-    #[structopt(long, global = true)]
+    #[clap(long, global = true)]
     profile: Option<String>,
 
     /// Overrides the default AWS region.
-    #[structopt(long, global = true)]
+    #[clap(long, global = true)]
     region: Option<String>,
 
     /// The subcommand to execute.
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     subcommand: subcommand::Subcommand,
 }
 

--- a/src/app/subcommand/debug.rs
+++ b/src/app/subcommand/debug.rs
@@ -3,10 +3,10 @@
 use crate::{app, errorln, outputln};
 
 /// The options for the subcommand.
-#[derive(structopt::StructOpt)]
+#[derive(clap::Parser)]
 pub struct Subcommand {
     /// Causes the command to produce an error.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     error: bool,
 }
 

--- a/src/app/subcommand/ecr.rs
+++ b/src/app/subcommand/ecr.rs
@@ -5,7 +5,7 @@ use crate::util::run;
 use crate::{app, err};
 
 /// The options for the subcommand.
-#[derive(structopt::StructOpt)]
+#[derive(clap::Parser)]
 pub struct Subcommand {}
 
 impl app::Execute for Subcommand {

--- a/src/app/subcommand/eks.rs
+++ b/src/app/subcommand/eks.rs
@@ -5,7 +5,7 @@ use crate::util::{run, term};
 use crate::{app, err};
 
 /// The options for the subcommand.
-#[derive(structopt::StructOpt)]
+#[derive(clap::Parser)]
 pub struct Subcommand {
     /// The name of the desired cluster.
     cluster: Option<String>,

--- a/src/app/subcommand/mod.rs
+++ b/src/app/subcommand/mod.rs
@@ -10,14 +10,8 @@ mod sso;
 
 use crate::app;
 
-/// A command line utility to simplify logging into AWS accounts and services.
-///
-/// This utility serves as a wrapper around the AWS CLI to extend functionality that it already
-/// provides. The goal is to merge together disparate but related commands into single subcommands
-/// that are easier to remember and use. The utility also leverages templating for profiles that
-/// may be shared with colleagues of the same organization, providing more consistent profile
-/// naming conventions and configuration settings.
-#[derive(structopt::StructOpt)]
+/// The subcommands available to the user.
+#[derive(clap::Parser)]
 pub enum Subcommand {
     /// Prints debugging messages for the application.
     #[cfg(debug_assertions)]
@@ -43,7 +37,7 @@ pub enum Subcommand {
     /// has a corresponding template, the AWS CLI profile will be created using the template. If
     /// the AWS CLI profile exists, or was created, it will be made an active AWS CLI profile.
     /// This activation removes the need to use the --profile option for every AWS CLI execution.
-    #[structopt(name = "use")]
+    #[clap(name = "use")]
     Profile(profile::Subcommand),
 
     /// Downloads profile templates from a URL.

--- a/src/app/subcommand/profile.rs
+++ b/src/app/subcommand/profile.rs
@@ -5,7 +5,7 @@ use crate::util::{run, shell, term};
 use crate::{err, errorln};
 
 /// The options for the subcommand.
-#[derive(structopt::StructOpt)]
+#[derive(clap::Parser)]
 pub struct Subcommand {}
 
 impl app::Execute for Subcommand {

--- a/src/app/subcommand/pull.rs
+++ b/src/app/subcommand/pull.rs
@@ -44,7 +44,7 @@ impl str::FromStr for Resolve {
 }
 
 /// The options for the subcommand.
-#[derive(structopt::StructOpt)]
+#[derive(clap::Parser)]
 pub struct Subcommand {
     /// How to handle the existing local profile templates.
     ///
@@ -54,7 +54,7 @@ pub struct Subcommand {
     /// in the local file are preserved unless a remote one of the same name is found. If
     /// "replace" is chosen, all of the local profiles will be removed before being replaced
     /// by the remote templates.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     resolve: Option<Resolve>,
 
     /// The URL to download the profile templates from.

--- a/src/app/subcommand/shell.rs
+++ b/src/app/subcommand/shell.rs
@@ -27,7 +27,7 @@ impl str::FromStr for Action {
 }
 
 /// The options for the subcommand.
-#[derive(structopt::StructOpt)]
+#[derive(clap::Parser)]
 pub struct Subcommand {
     /// What the subcommand should do with the shell environment.
     ///
@@ -37,7 +37,7 @@ pub struct Subcommand {
     action: Action,
 
     /// The path to the shell profile's startup script (e.g. ~/.bashrc).
-    #[structopt(short, long)]
+    #[clap(short, long)]
     init: Option<String>,
 
     /// The name of the shell used to manage the environment (e.g. bash).
@@ -47,7 +47,7 @@ pub struct Subcommand {
     /// open a ticket to request support for additional shells.
     ///
     /// The supported shells are: bash, zsh
-    #[structopt(short, long)]
+    #[clap(short, long)]
     shell: String,
 }
 

--- a/src/app/subcommand/sso.rs
+++ b/src/app/subcommand/sso.rs
@@ -12,7 +12,7 @@ const REQUIRED_SETTINGS: &[&str] = &[
 ];
 
 /// The options for the subcommand.
-#[derive(structopt::StructOpt)]
+#[derive(clap::Parser)]
 pub struct Subcommand {}
 
 impl app::Execute for Subcommand {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,15 @@
 //! A command line utility to simplify logging into AWS accounts and services.
+//!
+//! This utility serves as a wrapper around the AWS CLI to extend functionality that it already
+//! provides. The goal is to merge together disparate but related commands into single subcommands
+//! that are easier to remember and use. The utility also leverages templating for profiles that
+//! may be shared with colleagues of the same organization, providing more consistent profile
+//! naming conventions and configuration settings.
 
 mod app;
 mod util;
 
-use structopt::StructOpt;
+use clap::Parser;
 
 /// Primary entrypoint to the command line interface.
 ///
@@ -14,7 +20,7 @@ use structopt::StructOpt;
 /// `app::Application` instance could not be created, a clean up operation is still performed
 /// before exiting with the `clap::Error` returned by [`structopt::StructOpt::from_args_safe`].
 fn main() {
-    let mut app = app::Application::from_args_safe();
+    let mut app = app::Application::try_parse();
 
     if let Ok(app) = app.as_mut() {
         if let Err(error) = app.execute() {


### PR DESCRIPTION
Origin
======

Related to #13.

Additional Context
------------------

This PR migrates from structopt to clap v3, whose derive feature [seems to be the successor to structopt](https://github.com/TeXitoi/structopt/issues/516#issuecomment-989566094). Hopefully, this change alone is enough to support help text with color on Windows/PowerShell.