### PR TITLE
Creating a subcommand to generate RDS Proxy IAM auth tokens.

### DIFF
--- a/src/app/subcommand/mod.rs
+++ b/src/app/subcommand/mod.rs
@@ -5,6 +5,7 @@ mod ecr;
 mod eks;
 mod profile;
 mod pull;
+mod rds;
 mod shell;
 mod sso;
 
@@ -49,6 +50,14 @@ pub enum Subcommand {
     /// existing templates of the same name.
     Pull(pull::Subcommand),
 
+    /// Generates an authentication token to access RDS Proxy via IAM.
+    ///
+    /// This subcommand will prompt you to select one proxy out of any that are found in RDS Proxy
+    /// and whose status are "available". Once a proxy is selected, a new database authentication
+    /// token will be generated. It is important to note that a token will be successfully generated
+    /// even if you do not have the permissions necessary to access the proxy.
+    Rds(rds::Subcommand),
+
     /// Integrates the application into the shell environment.
     ///
     /// This subcommand is capable of modifying the shell profile to inject code required to
@@ -73,6 +82,7 @@ impl app::Execute for Subcommand {
             Self::Eks(cmd) => cmd.execute(context),
             Self::Profile(cmd) => cmd.execute(context),
             Self::Pull(cmd) => cmd.execute(context),
+            Self::Rds(cmd) => cmd.execute(context),
             Self::Shell(cmd) => cmd.execute(context),
             Self::Sso(cmd) => cmd.execute(context),
 

--- a/src/app/subcommand/rds.rs
+++ b/src/app/subcommand/rds.rs
@@ -64,7 +64,7 @@ impl app::Execute for Subcommand {
             .arg("--hostname")
             .arg(&proxy.endpoint)
             .arg("--port")
-            .arg(&self.port.as_deref().unwrap_or("5432"))
+            .arg(self.port.as_deref().unwrap_or("5432"))
             .arg("--username")
             .arg(&self.username)
             .pass_through(context)?;

--- a/src/app/subcommand/rds.rs
+++ b/src/app/subcommand/rds.rs
@@ -1,0 +1,125 @@
+//! A subcommand used to generate a token for accessing RDS Proxy using IAM.
+
+use crate::app::ErrorContext;
+use crate::util::{run, term};
+use crate::{app, err, errorln};
+use std::fmt;
+
+/// Represents an RDS Proxy that is available.
+struct Proxy {
+    /// The host name for the endpoint of the proxy.
+    endpoint: String,
+
+    /// The database engine family.
+    engine: String,
+
+    /// The name of the proxy.
+    name: String,
+
+    /// The flag used to indicate if TLS is required.
+    require_tls: bool,
+}
+
+impl fmt::Display for Proxy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+/// The options for the subcommand.
+#[derive(clap::Parser)]
+pub struct Subcommand {
+    /// The database port number.
+    #[clap(short, long)]
+    port: Option<String>,
+
+    /// The database username.
+    username: String,
+}
+
+impl app::Execute for Subcommand {
+    fn execute(&self, context: &mut impl app::Context) -> app::Result<()> {
+        let proxies = get_proxies(context)?;
+        let proxy = term::select("Please select an RDS Proxy:", &proxies)?;
+
+        if proxy.engine != "POSTGRESQL" && self.port.is_none() {
+            err!(
+                1,
+                "The database server port number is required for {} engines.",
+                proxy.engine
+            );
+        }
+
+        if proxy.require_tls {
+            errorln!(
+                context,
+                "Warning: This connection requires TLS to be used.\n"
+            )?;
+        }
+
+        run::Run::new("aws")
+            .with_aws_options(context)
+            .arg("rds")
+            .arg("generate-db-auth-token")
+            .arg("--hostname")
+            .arg(&proxy.endpoint)
+            .arg("--port")
+            .arg(&self.port.as_deref().unwrap_or("5432"))
+            .arg("--username")
+            .arg(&self.username)
+            .pass_through(context)?;
+
+        Ok(())
+    }
+}
+
+/// Retrieves a list of the available RDS Proxies.
+fn get_proxies(context: &impl app::Context) -> app::Result<Vec<Proxy>> {
+    let pairs = run::Run::new("aws")
+        .with_aws_options(context)
+        .arg("rds")
+        .arg("describe-db-proxies")
+        .arg("--query")
+        .arg("DBProxies[].[DBProxyName,Endpoint,EngineFamily,RequireTLS, Status]")
+        .arg("--output")
+        .arg("text")
+        .output()
+        .map(|output| output.trim().to_owned())
+        .with_context(|| "Could not get RDS Proxy host names from AWS CLI.".to_owned())?
+        .split('\n')
+        .map(|s| s.to_owned())
+        .collect::<Vec<String>>();
+
+    let mut host_names = Vec::new();
+
+    for pair in pairs {
+        let mut parts = pair
+            .split('\t')
+            .map(|s| s.to_owned())
+            .collect::<Vec<String>>();
+
+        let (status, require_tls, engine, endpoint, name) = (
+            parts.remove(4),
+            parts.remove(3),
+            parts.remove(2),
+            parts.remove(1),
+            parts.remove(0),
+        );
+
+        if status == "available" {
+            let proxy = Proxy {
+                require_tls: require_tls
+                    .to_lowercase()
+                    .parse::<bool>()
+                    .expect("The RequireTLS field from the AWS CLI is not a boolean value."),
+                endpoint,
+                engine,
+                name,
+            };
+
+            host_names.push(proxy);
+        }
+    }
+
+    Ok(host_names)
+}


### PR DESCRIPTION
Origin
======

Closes #8

Additional Context
------------------

There are a couple of pieces of information that we cannot infer from the data that is available to us, so it needs to be requested from the user where needed.
- For example, [PostgreSQL will always use port 5432](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/rds-proxy.html#rds-proxy.limits) but it is implied that it could be other ports for MySQL.
- There is also no way of determining the appropriate usernames to select from without having access to Secrets Manager, which will not be available in most cases.